### PR TITLE
feat: 예약 조회 API 및 UI 개선

### DIFF
--- a/ordly-admin/src/app/api/coupons/[id]/route.ts
+++ b/ordly-admin/src/app/api/coupons/[id]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../auth/[...nextauth]/route';
 
-const prisma = new PrismaClient();
-
-// Helper function to check ownership
-async function verifyCouponOwnership(couponId: string, userId: string): Promise<boolean> {
+async function verifyCouponOwnership(
+  couponId: string,
+  userId: string
+): Promise<boolean> {
   const coupon = await prisma.coupon.findUnique({
     where: { id: couponId },
     select: { storeId: true },
@@ -14,7 +14,10 @@ async function verifyCouponOwnership(couponId: string, userId: string): Promise<
   return coupon?.storeId === userId;
 }
 
-export async function PUT(req: NextRequest, context: { params: { id: string } }) {
+export async function PUT(
+  req: NextRequest,
+  context: { params: { id: string } }
+) {
   const session = await getServerSession(authOptions);
   // @ts-ignore
   if (!session || !session.user?.storeId) {
@@ -39,7 +42,14 @@ export async function PUT(req: NextRequest, context: { params: { id: string } })
     }
 
     const body = await req.json();
-    const { description, discountType, discountValue, validFrom, validUntil, isActive } = body;
+    const {
+      description,
+      discountType,
+      discountValue,
+      validFrom,
+      validUntil,
+      isActive,
+    } = body;
 
     const updatedCoupon = await prisma.coupon.update({
       where: { id: id },
@@ -63,7 +73,10 @@ export async function PUT(req: NextRequest, context: { params: { id: string } })
   }
 }
 
-export async function DELETE(req: NextRequest, context: { params: { id: string } }) {
+export async function DELETE(
+  req: NextRequest,
+  context: { params: { id: string } }
+) {
   const session = await getServerSession(authOptions);
   // @ts-ignore
   if (!session || !session.user?.storeId) {

--- a/ordly-admin/src/app/api/coupons/route.ts
+++ b/ordly-admin/src/app/api/coupons/route.ts
@@ -1,11 +1,8 @@
-
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]/route';
 import crypto from 'crypto';
-
-const prisma = new PrismaClient();
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -39,7 +36,8 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { description, discountType, discountValue, validFrom, validUntil } = body;
+    const { description, discountType, discountValue, validFrom, validUntil } =
+      body;
 
     const code = `COUPON${crypto.randomBytes(4).toString('hex').toUpperCase()}`;
     const storeId = session.user.storeId as string;

--- a/ordly-admin/src/app/api/reservations/[date]/route.ts
+++ b/ordly-admin/src/app/api/reservations/[date]/route.ts
@@ -23,17 +23,14 @@ export async function GET(
       return NextResponse.json({ error: 'Date parameter is required' }, { status: 400 });
     }
 
-    const selectedDate = new Date(date);
-    selectedDate.setHours(0, 0, 0, 0);
+    const [year, month, day] = date.split('-').map(Number);
+    const selectedDate = new Date(Date.UTC(year, month - 1, day));
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    const now = new Date();
+    const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 
-    const startOfDay = new Date(date);
-    startOfDay.setUTCHours(0, 0, 0, 0);
-
-    const endOfDay = new Date(date);
-    endOfDay.setUTCHours(23, 59, 59, 999);
+    const startOfDay = selectedDate;
+    const endOfDay = new Date(Date.UTC(year, month - 1, day, 23, 59, 59, 999));
 
     let statusFilter: ReservationStatus[];
 

--- a/ordly-admin/src/app/api/reservations/[date]/route.ts
+++ b/ordly-admin/src/app/api/reservations/[date]/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { ReservationStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { date: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    // @ts-ignore
+    if (!session || !session.user?.storeId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    // @ts-ignore
+    const storeId = session.user.storeId as string;
+
+    const { date } = params;
+    if (!date) {
+      return NextResponse.json({ error: 'Date parameter is required' }, { status: 400 });
+    }
+
+    const selectedDate = new Date(date);
+    selectedDate.setHours(0, 0, 0, 0);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const startOfDay = new Date(date);
+    startOfDay.setUTCHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(date);
+    endOfDay.setUTCHours(23, 59, 59, 999);
+
+    let statusFilter: ReservationStatus[];
+
+    if (selectedDate < today) {
+      // 과거: 방문(CONFIRMED), 취소(CANCELED)
+      statusFilter = [ReservationStatus.CONFIRMED, ReservationStatus.CANCELED];
+    } else {
+      // 오늘 또는 미래: 예정(CONFIRMED, REQUESTED), 취소(CANCELED)
+      statusFilter = [
+        ReservationStatus.CONFIRMED,
+        ReservationStatus.REQUESTED,
+        ReservationStatus.CANCELED,
+      ];
+    }
+
+    const reservations = await prisma.reservation.findMany({
+      where: {
+        storeId,
+        reservationTime: {
+          gte: startOfDay,
+          lte: endOfDay,
+        },
+        status: {
+          in: statusFilter,
+        },
+      },
+      orderBy: {
+        reservationTime: 'asc',
+      },
+    });
+
+    return NextResponse.json(reservations);
+  } catch (error) {
+    console.error('Error fetching reservations:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/ordly-admin/src/app/api/reservations/[date]/route.ts
+++ b/ordly-admin/src/app/api/reservations/[date]/route.ts
@@ -11,12 +11,10 @@ export async function GET(
   try {
     const session = await getServerSession(authOptions);
 
-    // @ts-ignore
-    if (!session || !session.user?.storeId) {
+    if (!session?.user?.storeId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    // @ts-ignore
-    const storeId = session.user.storeId as string;
+    const storeId = session.user.storeId;
 
     const { date } = params;
     if (!date) {

--- a/ordly-admin/src/components/common/calendar/calendar.tsx
+++ b/ordly-admin/src/components/common/calendar/calendar.tsx
@@ -3,32 +3,45 @@
 import { useCalendar } from '@/hooks/useCalendar.hooks';
 import CalendarHeader from './calendar-header';
 import CalendarGrid from './calendar-grid';
+import CardItem from '../card-item';
 
-export default function Calendar() {
-  const { 
-    year, 
-    month, 
-    monthGrid, 
-    selectedDate,
-    goToNextMonth, 
-    goToPrevMonth, 
-    handleSelectDate 
+type Props = {
+  selectedDate?: Date | null;
+  onDateClick?: (date: Date) => void;
+};
+
+export default function Calendar({
+  selectedDate: propSelectedDate,
+  onDateClick: propOnDateClick,
+}: Props) {
+  const {
+    year,
+    month,
+    monthGrid,
+    selectedDate: hookSelectedDate,
+    goToNextMonth,
+    goToPrevMonth,
+    handleSelectDate: hookHandleSelectDate,
   } = useCalendar();
 
+  const selectedDate =
+    propSelectedDate !== undefined ? propSelectedDate : hookSelectedDate;
+  const onDateClick = propOnDateClick || hookHandleSelectDate;
+
   return (
-    <div className="flex flex-col w-full h-full">
+    <CardItem>
       <CalendarHeader
         year={year}
         month={month}
         onPrev={goToPrevMonth}
         onNext={goToNextMonth}
       />
-      <CalendarGrid 
+      <CalendarGrid
         monthGrid={monthGrid}
         currentMonth={month}
         selectedDate={selectedDate}
-        onDateClick={handleSelectDate}
+        onDateClick={onDateClick}
       />
-    </div>
+    </CardItem>
   );
 }

--- a/ordly-admin/src/components/common/coupon-skeleton.tsx
+++ b/ordly-admin/src/components/common/coupon-skeleton.tsx
@@ -1,0 +1,77 @@
+import CardItem from '@/components/common/card-item';
+
+export default function CouponSkeleton() {
+  return (
+    <div className='flex flex-col p-4 h-full'>
+      <CardItem>
+        <div className='animate-pulse'>
+          {/* 헤더 스켈레톤 */}
+          <div className='flex justify-between items-center mb-4'>
+            <div className='h-7 bg-gray-200 rounded w-1/4'></div>
+            <div className='h-10 bg-gray-200 rounded-lg w-32'></div>
+          </div>
+
+          {/* 테이블 스켈레톤 */}
+          <table className='w-full text-left'>
+            {/* 테이블 헤더 */}
+            <thead>
+              <tr className='border-b text-gray-400'>
+                <th className='p-2 w-[20%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+                <th className='p-2 w-[20%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+                <th className='p-2 w-[10%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+                <th className='p-2 w-[10%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+                <th className='p-2 w-[20%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+                <th className='p-2 w-[10%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+                <th className='p-2 w-[10%]'>
+                  <div className='h-4 bg-gray-200 rounded'></div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...Array(12)].map((_, index) => (
+                <tr
+                  key={index}
+                  className='border-b last:border-b-0  text-gray-400'
+                >
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded'></div>
+                  </td>
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded'></div>
+                  </td>
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded'></div>
+                  </td>
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded'></div>
+                  </td>
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded'></div>
+                  </td>
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded-full w-14'></div>
+                  </td>
+                  <td className='p-2'>
+                    <div className='h-5 bg-gray-200 rounded w-12'></div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardItem>
+    </div>
+  );
+}

--- a/ordly-admin/src/components/common/reservation-skeleton.tsx
+++ b/ordly-admin/src/components/common/reservation-skeleton.tsx
@@ -1,0 +1,17 @@
+import CardItem from './card-item';
+
+export default function ReservationSkeleton() {
+  return (
+    <CardItem>
+      <div className='space-y-4 animate-pulse'>
+        <div className='h-5 bg-gray-200 rounded w-1/4'></div>
+        {[...Array(5)].map((_, index) => (
+          <div key={index} className='space-y-2'>
+            <div className='h-4 bg-gray-200 rounded w-5/6'></div>
+            <div className='h-3 bg-gray-200 rounded w-3/4'></div>
+          </div>
+        ))}
+      </div>
+    </CardItem>
+  );
+}

--- a/ordly-admin/src/features/coupons/components/coupons.tsx
+++ b/ordly-admin/src/features/coupons/components/coupons.tsx
@@ -13,6 +13,7 @@ import {
   deleteCoupon,
   CreateCouponDto,
 } from '../api/coupons.api';
+import CouponSkeleton from '@/components/common/coupon-skeleton';
 
 export default function Coupons() {
   const queryClient = useQueryClient();
@@ -89,7 +90,7 @@ export default function Coupons() {
     }
   };
 
-  if (isLoading) return <div className='text-center justify-center flex'>Loading...</div>;
+  if (isLoading) return <CouponSkeleton />
   if (isError) return <div>Error loading coupons: {error.message}</div>;
 
   return (

--- a/ordly-admin/src/features/reservations/api/reservations.api.ts
+++ b/ordly-admin/src/features/reservations/api/reservations.api.ts
@@ -1,0 +1,11 @@
+import { Reservation } from '@prisma/client';
+
+export const getReservationsByDate = async (date: string): Promise<Reservation[]> => {
+  const response = await fetch(`/api/reservations/${date}`);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch reservations');
+  }
+
+  return response.json();
+};

--- a/ordly-admin/src/features/reservations/components/reservation-item.tsx
+++ b/ordly-admin/src/features/reservations/components/reservation-item.tsx
@@ -7,6 +7,12 @@ const statusStyles: { [key in ReservationStatus]: string } = {
   cancelled: 'bg-red-100 text-red-800',
 };
 
+const statusLabels: { [key in ReservationStatus]: string } = {
+  confirmed: '확정',
+  completed: '방문완료',
+  cancelled: '취소',
+};
+
 type Props = {
   reservation: Reservation;
 };
@@ -14,11 +20,10 @@ type Props = {
 export default function ReservationItem({ reservation }: Props) {
   return (
     <li className='flex flex-col gap-1'>
-      <div className='flex justify-between'>
+      <div className='flex justify-between items-center'>
         <div>
           <p className='font-bold text-gray-900'>
-            {reservation.time} - {reservation.name} 님 ({reservation.partySize}
-            명)
+            {reservation.time} - {reservation.name} 님 ({reservation.partySize}명)
           </p>
           <div className='flex items-center gap-2 text-sm text-gray-600'>
             <Phone size={12} />
@@ -26,13 +31,11 @@ export default function ReservationItem({ reservation }: Props) {
           </div>
         </div>
         <span
-          className={`flex my-2 px-2 items-center rounded-3xl text-xs ${
+          className={`flex my-2 px-3 py-1 items-center rounded-full text-xs font-semibold ${
             statusStyles[reservation.status]
           }`}
         >
-          {reservation.status === 'confirmed' && '예정'}
-          {reservation.status === 'completed' && '완료'}
-          {reservation.status === 'cancelled' && '취소'}
+          {statusLabels[reservation.status]}
         </span>
       </div>
     </li>

--- a/ordly-admin/src/features/reservations/components/reservation-list.tsx
+++ b/ordly-admin/src/features/reservations/components/reservation-list.tsx
@@ -1,48 +1,143 @@
-// src/components/reservations/ReservationList.tsx
+'use client';
+
+import { useState, useEffect } from 'react';
 import CardItem from '@/components/common/card-item';
 import ReservationItem from './reservation-item';
-import { Reservation } from '@/types/types';
-
-const sampleReservations: Reservation[] = [
-  {
-    id: 1,
-    time: '14:00',
-    name: '김OO',
-    partySize: 4,
-    phone: '010-1234-5678',
-    request: '창가 자리 부탁드립니다.',
-    status: 'confirmed',
-  },
-  {
-    id: 2,
-    time: '18:30',
-    name: '박XX',
-    partySize: 2,
-    phone: '010-8765-4321',
-    status: 'confirmed',
-  },
-  {
-    id: 3,
-    time: '19:00',
-    name: '이XX',
-    partySize: 5,
-    phone: '010-1111-2222',
-    status: 'completed',
-  },
-];
+import {
+  Reservation as PrismaReservation,
+  ReservationStatus as PrismaReservationStatus,
+} from '@prisma/client';
+import {
+  Reservation as FrontendReservation,
+  ReservationStatus as FrontendReservationStatus,
+} from '@/types/types';
+import ReservationSkeleton from '@/components/common/reservation-skeleton';
 
 type Props = {
-  title: string;
+  reservations: PrismaReservation[] | undefined;
+  isLoading: boolean;
+  selectedDate: Date | null;
 };
 
-export default function ReservationList({ title}: Props) {
+// Prisma Reservation 타입을 Frontend Reservation 타입으로 변환하는 함수
+const transformReservation = (
+  res: PrismaReservation,
+  index: number,
+  isPast: boolean
+): FrontendReservation => {
+  let status: FrontendReservationStatus;
+
+  if (isPast) {
+    status = res.status === 'CONFIRMED' ? 'completed' : 'cancelled';
+  } else {
+    if (res.status === 'REQUESTED' || res.status === 'CONFIRMED') {
+      status = 'confirmed';
+    } else {
+      status = 'cancelled';
+    }
+  }
+
+  return {
+    id: index, // types.ts의 id가 number이므로 index 사용
+    time: new Date(res.reservationTime).toLocaleTimeString('ko-KR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }),
+    name: res.customerName,
+    partySize: res.numberOfGuests,
+    phone: res.customerPhone,
+    status: status,
+  };
+};
+
+export default function ReservationList({
+  reservations,
+  isLoading,
+  selectedDate,
+}: Props) {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!isClient) {
+    return <ReservationSkeleton />;
+  }
+
+  if (!selectedDate) {
+    return (
+      <CardItem title='예약 정보'>
+        <div className='flex items-center justify-center h-full text-gray-500'>
+          캘린더에서 날짜를 선택해주세요.
+        </div>
+      </CardItem>
+    );
+  }
+
+  if (isLoading) {
+    return <ReservationSkeleton />;
+  }
+
+  if (!reservations || reservations.length === 0) {
+    return (
+      <CardItem title='예약 정보'>
+        <div className='flex items-center justify-center h-full text-gray-500'>
+          해당 날짜에 예약이 없습니다.
+        </div>
+      </CardItem>
+    );
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const isPastDate = selectedDate < today;
+
+  const transformedReservations = reservations.map((res, i) =>
+    transformReservation(res, i, isPastDate)
+  );
+
+  const scheduled = transformedReservations.filter(
+    (r) => r.status === 'confirmed'
+  );
+  const completed = transformedReservations.filter(
+    (r) => r.status === 'completed'
+  );
+  const cancelled = transformedReservations.filter(
+    (r) => r.status === 'cancelled'
+  );
+
   return (
-    <CardItem title={title}>
-      <ul className='space-y-3 flex-grow overflow-y-auto'>
-        {sampleReservations.map((res) => (
-          <ReservationItem key={res.id} reservation={res} />
-        ))}
-      </ul>
+    <CardItem title='예약 목록' className='flex-grow overflow-y-auto'>
+      <div className='space-y-4'>
+        {isPastDate
+          ? // 과거: 방문 완료 목록
+            completed.length > 0 && (
+              <div className='flex flex-col gap-2'>
+                {completed.map((res) => (
+                  <ReservationItem key={res.id} reservation={res} />
+                ))}
+              </div>
+            )
+          : // 오늘 또는 미래: 예정 목록
+            scheduled.length > 0 && (
+              <div className='flex flex-col gap-2'>
+                {scheduled.map((res) => (
+                  <ReservationItem key={res.id} reservation={res} />
+                ))}
+              </div>
+            )}
+
+        {/* 취소 목록 */}
+        {cancelled.length > 0 && (
+          <div className='flex flex-col gap-2'>
+            {cancelled.map((res) => (
+              <ReservationItem key={res.id} reservation={res} />
+            ))}
+          </div>
+        )}
+      </div>
     </CardItem>
   );
 }

--- a/ordly-admin/src/features/reservations/components/reservation-list.tsx
+++ b/ordly-admin/src/features/reservations/components/reservation-list.tsx
@@ -38,7 +38,7 @@ const transformReservation = (
   }
 
   return {
-    id: index, // types.ts의 id가 number이므로 index 사용
+    id: res.id, // Prisma에서 제공하는 고유 id 사용
     time: new Date(res.reservationTime).toLocaleTimeString('ko-KR', {
       hour: '2-digit',
       minute: '2-digit',

--- a/ordly-admin/src/features/reservations/components/reservation.tsx
+++ b/ordly-admin/src/features/reservations/components/reservation.tsx
@@ -1,20 +1,29 @@
-import { Reservation } from '@/types/types';
+'use client';
+
+import { useCalendar } from '@/hooks/useCalendar.hooks';
+import Calendar from '@/components/common/calendar/calendar';
 import ReservationList from './reservation-list';
-import ReservationCalendar from './reservations-calendar';
+import { useReservations } from '@/hooks/useReservations.hooks';
+import { formatDateToYYYYMMDD } from '@/utils/date';
 
+export default function Reservation() {
+  const { selectedDate, handleSelectDate } = useCalendar();
+  const formattedDate = selectedDate ? formatDateToYYYYMMDD(selectedDate) : '';
 
-export default function ReservationPage() {
+  const { data: reservations, isLoading } = useReservations(formattedDate);
+
   return (
     <div className='flex-1 grid grid-cols-1 md:grid-cols-3 flex-grow gap-4 p-4 sm:p-2 lg:p-4'>
-      
       <div className='md:col-span-2'>
-        <ReservationCalendar />
+        <Calendar onDateClick={handleSelectDate} selectedDate={selectedDate} />
       </div>
 
       <div className='md:col-span-1 flex flex-col gap-4'>
-        <ReservationList title='예정' />
-        <ReservationList title='취소' />
-        <ReservationList title='방문 완료'/>
+        <ReservationList
+          reservations={reservations}
+          isLoading={isLoading}
+          selectedDate={selectedDate}
+        />
       </div>
     </div>
   );

--- a/ordly-admin/src/hooks/useReservations.hooks.ts
+++ b/ordly-admin/src/hooks/useReservations.hooks.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getReservationsByDate } from '@/features/reservations/api/reservations.api';
+
+export const useReservations = (date: string) => {
+  const isServer = typeof window === 'undefined';
+
+  return useQuery({
+    queryKey: ['reservations', date],
+    queryFn: () => getReservationsByDate(date),
+    // 서버에서는 쿼리를 비활성화하고, 클라이언트에서만 날짜가 있을 때 실행
+    enabled: !isServer && !!date,
+  });
+};

--- a/ordly-admin/src/utils/date.ts
+++ b/ordly-admin/src/utils/date.ts
@@ -1,16 +1,3 @@
-/*
- *
- * @purpose
- * - 이 모듈은 React나 특정 UI 프레임워크에 의존하지 않는 순수 TypeScript 날짜 계산 함수들을 제공
- * - JavaScript의 네이티브 `Date` 객체를 사용하여 캘린더 표시에 필요한 모든 계산을 수행
- * - 프로젝트 전반에서 재사용될 수 있는 유틸리티 함수를 포함
- *
- * @functions
- * - getMonthDetails(year, month): 특정 연월의 시작 요일과 총 일수를 계산하여 반환
- * - generateCalendarGrid(year, month): `getMonthDetails`를 사용하여 6주치(42일)에 해당하는
- * 날짜들이 포함된 2차원 Date 배열을 생성
- */
-
 export const getMonthDetails = (year: number, month: number) => {
   const firstDay = new Date(year, month, 1).getDay();
   return { firstDay };
@@ -30,4 +17,11 @@ export const calendarGrid = (year: number, month: number): Date[][] => {
     grid.push(week);
   }
   return grid;
+};
+
+export const formatDateToYYYYMMDD = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };


### PR DESCRIPTION
- 날짜별 예약 조회를 위한 API 라우트 추가, React Query 훅과 예약 API 클라이언트 구현.
- 로딩 상태 표시를 위한 스켈레톤 컴포넌트 추가.
- 캘린더가 props를 받을 수 있도록 리팩터링.
- 예약 목록이 실제 데이터, 로딩, 비어 있는 상태를 표시하도록 개선.
- 쿠폰 API를 공유 Prisma 클라이언트 사용으로 변경하고 코드 포맷팅 개선.
- 예약 항목 UI와 상태 라벨 일부 개선.

→ 예약 관리 흐름을 데이터 기반으로 강화하고 사용자 경험을 개선함.

close #13